### PR TITLE
Small style changes

### DIFF
--- a/AWU2UDDF/Models/HealthKitManager.swift
+++ b/AWU2UDDF/Models/HealthKitManager.swift
@@ -24,7 +24,7 @@ class HealthKitManager {
                 waterTemp
             ]
             
-            healthStore.requestAuthorization(toShare: [underwaterDepth], read: healthKitTypesToRead ) { success, error in
+            healthStore.requestAuthorization(toShare: [], read: healthKitTypesToRead ) { success, error in
                 if success {
                     readDepths()
                 } else if error != nil {

--- a/AWU2UDDF/Models/HealthKitViewModel.swift
+++ b/AWU2UDDF/Models/HealthKitViewModel.swift
@@ -37,16 +37,8 @@ class HealthKitViewModel: ObservableObject {
         print("Status is:", status)
         
         DispatchQueue.main.async { [self] in
-            switch status {
-            case .notDetermined:
-                isAuthorized = false
-            case .sharingDenied:
-                isAuthorized = false
-            case .sharingAuthorized:
-                isAuthorized = true
-            @unknown default:
-                isAuthorized = false
-            }
+            // Because the app only asks for read permission, not to write ("share") anything, status will either be `notDetermined` or `sharingDenied`
+            isAuthorized = status != .notDetermined
         }
     }
     

--- a/AWU2UDDF/Models/HealthKitViewModel.swift
+++ b/AWU2UDDF/Models/HealthKitViewModel.swift
@@ -36,18 +36,18 @@ class HealthKitViewModel: ObservableObject {
         
         print("Status is:", status)
         
-        switch status {
-        case .notDetermined:
-            isAuthorized = false
-        case .sharingDenied:
-            isAuthorized = false
-        case .sharingAuthorized:
-            DispatchQueue.main.async {
-                self.isAuthorized = true
+        DispatchQueue.main.async { [self] in
+            switch status {
+            case .notDetermined:
+                isAuthorized = false
+            case .sharingDenied:
+                isAuthorized = false
+            case .sharingAuthorized:
+                isAuthorized = true
+            @unknown default:
+                isAuthorized = false
             }
-        @unknown default:
-            isAuthorized = false
-      }
+        }
     }
     
     func readDiveDepths() {

--- a/AWU2UDDF/Views/DiveExportView.swift
+++ b/AWU2UDDF/Views/DiveExportView.swift
@@ -33,7 +33,7 @@ struct DiveExportView: View {
                     .foregroundColor(.white)
             }
             .frame(width: 320, height: 55)
-            .background(Color(.orange))
+            .background(.orange)
             .cornerRadius(10)
             .padding()
             .fileExporter(isPresented: $isExporting, document: UDDFFile(initialText: dive.buildUDDF(temps: temps)), contentType: UTType.xml, defaultFilename: dive.defaultUDDFFilename()) {      result in


### PR DESCRIPTION
Just a few little changes to "clean up" things a bit.

The change to the HealthKitManager makes it not say that it will be writing data to HealthKit when asking for permissions (since, as best I can tell, the app doesn't do that).

The change in HealthKitViewModel addresses the warning about other values not being published properly -- without this, if the authorization status changes from authorized to un-authorized, the change will be reflected properly in the UI.

The other change is just a little stylistic thing...