### PR TITLE
Set frame on button label instead of button itself

### DIFF
--- a/AWU2UDDF/Views/ContentView.swift
+++ b/AWU2UDDF/Views/ContentView.swift
@@ -62,8 +62,8 @@ struct ContentView: View {
                         Text("Authorize HealthKit")
                             .font(.headline)
                             .foregroundColor(.white)
+                            .frame(width: 320, height: 55)
                     }
-                    .frame(width: 320, height: 55)
                     .background(Color(.orange))
                     .cornerRadius(10)
                 }

--- a/AWU2UDDF/Views/DiveExportView.swift
+++ b/AWU2UDDF/Views/DiveExportView.swift
@@ -31,8 +31,8 @@ struct DiveExportView: View {
                 Text("Export Dive")
                     .font(.headline)
                     .foregroundColor(.white)
+                    .frame(width: 320, height: 55)
             }
-            .frame(width: 320, height: 55)
             .background(Color(.orange))
             .cornerRadius(10)
             .padding()


### PR DESCRIPTION
This makes the tap target be the whole visible button, instead of just the text.

Wanting to fix this was the reason I asked you about contributing on ScubaBoard 😅 