### PR TITLE
Export data cleanup & speed-up

### DIFF
--- a/AWU2UDDF/Models/DiveModel.swift
+++ b/AWU2UDDF/Models/DiveModel.swift
@@ -39,15 +39,7 @@ class Dive: Identifiable, Hashable, Equatable {
     }
     
     func maxDepth() -> Double {
-        var maxDepth = 0.0
-        
-        for sample in self.profile {
-            if sample.depth > maxDepth {
-                maxDepth = sample.depth
-            }
-        }
-        return maxDepth
-        
+        return profile.max(by: { s1, s2 in s1.depth <= s2.depth })?.depth ?? 0
     }
     
     func avgDepth() {

--- a/AWU2UDDF/Models/DiveModel.swift
+++ b/AWU2UDDF/Models/DiveModel.swift
@@ -57,7 +57,7 @@ class Dive: Identifiable, Hashable, Equatable {
         return duration
     }
        
-    func buildUDDF (temps: [Temp_Sample]) -> String {
+    func buildUDDF (temps: [TemperatureSample]) -> String {
         return uddfFile.buildUDDFString(startTime: self.startTime, profile: self.profile, temps: temps)
     }
     

--- a/AWU2UDDF/Models/DiveModel.swift
+++ b/AWU2UDDF/Models/DiveModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import HealthKit
 
-class Depth_Sample {
+class DepthSample {
     var start : Date
     var end : Date
     var depth: Double
@@ -22,7 +22,7 @@ class Depth_Sample {
 
 class Dive: Identifiable, Hashable, Equatable {
     var startTime : Date
-    var profile: [Depth_Sample] = []
+    var profile: [DepthSample] = []
     var uddfFile: UDDF
     
     init (startTime: Date) {

--- a/AWU2UDDF/Models/DiveModel.swift
+++ b/AWU2UDDF/Models/DiveModel.swift
@@ -42,8 +42,9 @@ class Dive: Identifiable, Hashable, Equatable {
         return profile.max(by: { s1, s2 in s1.depth <= s2.depth })?.depth ?? 0
     }
     
-    func avgDepth() {
-        
+    func avgDepth() -> Double {
+        guard profile.count > 0 else { return 0 }
+        return profile.reduce(0, { total, sample in total + sample.depth }) / Double(profile.count)
     }
     
     func duration () -> Double {

--- a/AWU2UDDF/Models/DiveModel.swift
+++ b/AWU2UDDF/Models/DiveModel.swift
@@ -38,7 +38,7 @@ class Dive: Identifiable, Hashable, Equatable {
         return lhs.startTime == rhs.startTime
     }
     
-    func MaxDepth () -> Double {
+    func maxDepth() -> Double {
         var maxDepth = 0.0
         
         for sample in self.profile {
@@ -50,11 +50,11 @@ class Dive: Identifiable, Hashable, Equatable {
         
     }
     
-    func AvgDepth () {
+    func avgDepth() {
         
     }
     
-    func Duration () -> Double {
+    func duration () -> Double {
         guard let endTime = profile.last?.end else {
             return 0.0
         }

--- a/AWU2UDDF/Models/HealthKitManager.swift
+++ b/AWU2UDDF/Models/HealthKitManager.swift
@@ -64,8 +64,8 @@ class HealthKitManager {
                     if (diveList.isEmpty == false) {
                         print ("Dive Summary")
                         print ("  Start Time: ", dateFormatter.string(from: thisDiveStart!))
-                        print ("  Duration: ", Int((diveList.last!.Duration()+59.0)/60.0) as Any, "minutes")
-                        print ("  Max Depth: ", Int(diveList.last!.MaxDepth()) as Any, "meters")
+                        print ("  Duration: ", Int((diveList.last!.duration()+59.0)/60.0) as Any, "minutes")
+                        print ("  Max Depth: ", Int(diveList.last!.maxDepth()) as Any, "meters")
                     }
                     thisDiveStart = diveDates.start
                     diveList.append(Dive(startTime: thisDiveStart!))

--- a/AWU2UDDF/Models/HealthKitManager.swift
+++ b/AWU2UDDF/Models/HealthKitManager.swift
@@ -73,7 +73,7 @@ class HealthKitManager {
                 lastDiveEnd = diveDates.end
                 let currentDive = diveList.last
                 
-                currentDive?.profile.append(Depth_Sample(start: diveDates.start, end: diveDates.end, depth: (result.doubleValue(for: HKUnit.meter()))))
+                currentDive?.profile.append(DepthSample(start: diveDates.start, end: diveDates.end, depth: (result.doubleValue(for: HKUnit.meter()))))
             }
 
             completion(diveList)

--- a/AWU2UDDF/Models/HealthKitManager.swift
+++ b/AWU2UDDF/Models/HealthKitManager.swift
@@ -84,9 +84,9 @@ class HealthKitManager {
         
     }
 
-    func readWaterTemps(forToday: Date, healthStore: HKHealthStore, completion: @escaping ([Temp_Sample]) -> Void) {
+    func readWaterTemps(forToday: Date, healthStore: HKHealthStore, completion: @escaping ([TemperatureSample]) -> Void) {
         
-        var temps: [Temp_Sample] = []
+        var temps: [TemperatureSample] = []
 
         guard let waterTempType = HKQuantityType.quantityType(forIdentifier: .waterTemperature) else { return }
         
@@ -103,7 +103,7 @@ class HealthKitManager {
 //            print ("Temp Results: ", result)
             
             if let sampleDate = dates {
-                temps.append(Temp_Sample(start: sampleDate.start, end: sampleDate.end ,temp: result.doubleValue(for: HKUnit.degreeCelsius())))
+                temps.append(TemperatureSample(start: sampleDate.start, end: sampleDate.end ,temp: result.doubleValue(for: HKUnit.degreeCelsius())))
             }
             completion(temps)
         }

--- a/AWU2UDDF/Models/HealthKitViewModel.swift
+++ b/AWU2UDDF/Models/HealthKitViewModel.swift
@@ -13,7 +13,7 @@ class HealthKitViewModel: ObservableObject {
     private var healthStore = HKHealthStore()
     private var healthKitManager = HealthKitManager()
     @Published var diveList: [Dive] = []
-    @Published var temps: [Temp_Sample] = []
+    @Published var temps: [TemperatureSample] = []
     @Published var isAuthorized = false
     
     let debug: Bool = false

--- a/AWU2UDDF/Models/HealthKitViewModel.swift
+++ b/AWU2UDDF/Models/HealthKitViewModel.swift
@@ -96,7 +96,7 @@ class HealthKitViewModel: ObservableObject {
                 let depth: Double = Double(i)
                 let endDate = curDate.addingTimeInterval(10)
                 
-                let sample: Depth_Sample = .init(start: curDate, end: endDate, depth: depth)
+                let sample: DepthSample = .init(start: curDate, end: endDate, depth: depth)
                 sampleDive.profile.append(sample)
                 curDate = endDate
             }
@@ -104,7 +104,7 @@ class HealthKitViewModel: ObservableObject {
                 let depth: Double = Double(80-i)
                 let endDate = curDate.addingTimeInterval(10)
                 
-                let sample: Depth_Sample = .init(start: curDate, end: endDate, depth: depth)
+                let sample: DepthSample = .init(start: curDate, end: endDate, depth: depth)
                 sampleDive.profile.append(sample)
                 curDate = endDate
             }

--- a/AWU2UDDF/Models/TempModel.swift
+++ b/AWU2UDDF/Models/TempModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class Temp_Sample {
+class TemperatureSample {
     var start : Date
     var end : Date
     var temp: Double

--- a/AWU2UDDF/Models/UDDFModel.swift
+++ b/AWU2UDDF/Models/UDDFModel.swift
@@ -16,7 +16,7 @@ class UDDF {
     }
     
     // Search for a temperature sample that has a particular start to the time interval
-    func searchTemps(date: Date, temps: [Temp_Sample]) -> Double {
+    func searchTemps(date: Date, temps: [TemperatureSample]) -> Double {
         for tempSample in temps {
             if tempSample.start == date {
                 // matched a sample start time so return temperature
@@ -68,7 +68,7 @@ class UDDF {
     }
 
     // Build the <profile> section of UDDF by matching depth samples with temperature samples
-    func profileDataString(startTime: Date, profile: [Depth_Sample], temps: [Temp_Sample]) -> String {
+    func profileDataString(startTime: Date, profile: [Depth_Sample], temps: [TemperatureSample]) -> String {
         var xmlString = ""
 
         xmlString += "  <profiledata>\n"
@@ -112,7 +112,7 @@ class UDDF {
         return xmlString
     }
     
-    func buildUDDFString (startTime: Date, profile: [Depth_Sample], temps: [Temp_Sample]) -> String {
+    func buildUDDFString (startTime: Date, profile: [Depth_Sample], temps: [TemperatureSample]) -> String {
         print ("Total Temps: \(temps.count)")
         self.uddfString = ""
         uddfString =  "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"

--- a/AWU2UDDF/Models/UDDFModel.swift
+++ b/AWU2UDDF/Models/UDDFModel.swift
@@ -68,7 +68,7 @@ class UDDF {
     }
 
     // Build the <profile> section of UDDF by matching depth samples with temperature samples
-    func profileDataString(startTime: Date, profile: [Depth_Sample], temps: [TemperatureSample]) -> String {
+    func profileDataString(startTime: Date, profile: [DepthSample], temps: [TemperatureSample]) -> String {
         var xmlString = ""
 
         xmlString += "  <profiledata>\n"
@@ -112,7 +112,7 @@ class UDDF {
         return xmlString
     }
     
-    func buildUDDFString (startTime: Date, profile: [Depth_Sample], temps: [TemperatureSample]) -> String {
+    func buildUDDFString (startTime: Date, profile: [DepthSample], temps: [TemperatureSample]) -> String {
         print ("Total Temps: \(temps.count)")
         self.uddfString = ""
         uddfString =  "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"

--- a/AWU2UDDF/Models/UDDFModel.swift
+++ b/AWU2UDDF/Models/UDDFModel.swift
@@ -55,7 +55,7 @@ class UDDF {
     }
 
     // Build the <profile> section of UDDF by matching depth samples with temperature samples
-    func profileDataString(startTime: Date, profile: [Depth_Sample], temps: [Date:Temp_Sample]) -> String {
+    func profileDataString(startTime: Date, profile: [DepthSample], temps: [Date:TemperatureSample]) -> String {
         var xmlString = ""
 
         xmlString += "  <profiledata>\n"

--- a/AWU2UDDF/Models/UDDFModel.swift
+++ b/AWU2UDDF/Models/UDDFModel.swift
@@ -15,19 +15,6 @@ class UDDF {
         self.uddfString = ""
     }
     
-    // Search for a temperature sample that has a particular start to the time interval
-    func searchTemps(date: Date, temps: [TemperatureSample]) -> Double {
-        for tempSample in temps {
-            if tempSample.start == date {
-                // matched a sample start time so return temperature
-                return tempSample.temp
-            }
-        }
-        
-        // return -999.9 if no matching sample is found
-        return -999.9
-    }
-
     // Build the <generator> section of UDDF
     func generatorString() -> String {
         var xmlString = ""
@@ -68,7 +55,7 @@ class UDDF {
     }
 
     // Build the <profile> section of UDDF by matching depth samples with temperature samples
-    func profileDataString(startTime: Date, profile: [DepthSample], temps: [TemperatureSample]) -> String {
+    func profileDataString(startTime: Date, profile: [Depth_Sample], temps: [Date:Temp_Sample]) -> String {
         var xmlString = ""
 
         xmlString += "  <profiledata>\n"
@@ -89,17 +76,14 @@ class UDDF {
 
             let depthMeters = sample.depth
 
-            // find the matching temperature sample if it exists
-            let tempCelcius = searchTemps(date: sample.start, temps: temps)
-
             xmlString += "          <waypoint>\n"
             xmlString += "            <depth>" + String(format: "%.3f", depthMeters) + "</depth>\n"
             xmlString += "            <divetime>" + String(format: "%.3f",sampleTime) + "</divetime>\n"
 
             // Check if temperature sample exists, and if so add the <temperature> reading to UDDF
             // string. UDDF measures temperatures in Kelvin, so add 273.15 to centrigrade temperature
-            if tempCelcius != -999.9 {
-                xmlString += "            <temperature>" + String(format: "%.1f", (tempCelcius + 273.15)) + "</temperature>\n"
+            if let tempSample = temps[sample.start] {
+                xmlString += "            <temperature>" + String(format: "%.1f", (tempSample.temp + 273.15)) + "</temperature>\n"
             }
             xmlString += "          </waypoint>\n"
         }
@@ -114,6 +98,7 @@ class UDDF {
     
     func buildUDDFString (startTime: Date, profile: [DepthSample], temps: [TemperatureSample]) -> String {
         print ("Total Temps: \(temps.count)")
+        let tempsByDate = Dictionary(grouping: temps, by: { temp in temp.start }).mapValues({ $0.first! })
         self.uddfString = ""
         uddfString =  "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
         uddfString += "<uddf xmlns=\"http://www.streit.cc/uddf/3.2/\" version=\"3.2.0\">\n"
@@ -121,7 +106,7 @@ class UDDF {
         uddfString += diverString()
         uddfString += "  <divesite/>\n"
         uddfString += "  <gasdefinitions/>\n"
-        uddfString += profileDataString(startTime: startTime, profile: profile, temps: temps)
+        uddfString += profileDataString(startTime: startTime, profile: profile, temps: tempsByDate)
         uddfString += "</uddf>\n"
         return self.uddfString
     }

--- a/AWU2UDDF/Views/ContentView.swift
+++ b/AWU2UDDF/Views/ContentView.swift
@@ -23,8 +23,8 @@ struct ContentView: View {
     private var displayedDives: [Dive] {
         get {
             return vm.diveList
-                .filter({ dive in !filterShortDives || dive.Duration() > Double(settings.shortDiveDurationMinutes) * 60 })
-                .filter({ dive in !filterDeepDives || dive.MaxDepth() > settings.deepDiveDepthMetres })
+                .filter({ dive in !filterShortDives || dive.duration() > Double(settings.shortDiveDurationMinutes) * 60 })
+                .filter({ dive in !filterDeepDives || dive.maxDepth() > settings.deepDiveDepthMetres })
                 .filter({ dive in dive.startTime >= filterDateStart && dive.startTime <= filterDateEnd})
         }
     }

--- a/AWU2UDDF/Views/DiveExportView.swift
+++ b/AWU2UDDF/Views/DiveExportView.swift
@@ -12,7 +12,18 @@ struct DiveExportView: View {
     let dive: Dive
     let temps: [TemperatureSample]
     
-    @State var isExporting = false
+    @State private var isExporting = false
+    
+    @State private var exportDocument: UDDFFile? = nil
+    
+    private func generateExportDocument() {
+        DispatchQueue.global(qos: .userInitiated).async { [self] in
+            let document = UDDFFile(initialText: dive.buildUDDF(temps: temps))
+            DispatchQueue.main.async { [self] in
+                self.exportDocument = document
+            }
+        }
+    }
     
     @EnvironmentObject var settings: Settings
     
@@ -29,18 +40,21 @@ struct DiveExportView: View {
             Text("Max Depth: \(settings.displayDepth(metres: dive.maxDepth(), shortUnits: false))").padding()
             Text("Average Depth: \(settings.displayDepth(metres: dive.avgDepth(), shortUnits: false))").padding()
     
-            Button {
-                isExporting = true
-            } label: {
-                Text("Export Dive")
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(width: 320, height: 55)
-            }
-            .background(.orange)
-            .cornerRadius(10)
-            .padding()
-            .fileExporter(isPresented: $isExporting, document: UDDFFile(initialText: dive.buildUDDF(temps: temps)), contentType: UTType.xml, defaultFilename: dive.defaultUDDFFilename()) { result in
+            ZStack {
+                Button {
+                    isExporting = true
+                } label: {
+                    Text("Export Dive")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(width: 320, height: 55)
+                }
+                .background(.orange)
+                .cornerRadius(10)
+                .padding()
+                .opacity(exportDocument == nil ? 0.5 : 1)
+                .disabled(exportDocument == nil)
+                .fileExporter(isPresented: $isExporting, document: exportDocument, contentType: UTType.xml, defaultFilename: dive.defaultUDDFFilename()) {      result in
                     switch result {
                     case .success(let url):
                         print("Saved to \(url)")
@@ -48,9 +62,14 @@ struct DiveExportView: View {
                         print(error.localizedDescription)
                     }
                 }
-            Spacer()
-            Spacer()
-        }
+                if exportDocument == nil {
+                    ProgressView()
+                }
+            }
+                Spacer()
+                Spacer()
+            }
+        .onAppear(perform: self.generateExportDocument)
     }
 }
 

--- a/AWU2UDDF/Views/DiveExportView.swift
+++ b/AWU2UDDF/Views/DiveExportView.swift
@@ -25,7 +25,7 @@ struct DiveExportView: View {
             Spacer()
             Text("Dive Time: \(settings.dateFormatter.string(from: dive.startTime))")
                 .font(.title3).padding()
-            Text("Duration: \(Int((dive.Duration() + 59.0) / 60.0)) min").padding()
+            Text("Duration: \(Int((dive.duration() + 59.0) / 60.0)) min").padding()
             Text("Max Depth: \(settings.displayDepth(metres: dive.MaxDepth(), shortUnits: false))").padding()
     
             Button {

--- a/AWU2UDDF/Views/DiveExportView.swift
+++ b/AWU2UDDF/Views/DiveExportView.swift
@@ -10,7 +10,7 @@ import UniformTypeIdentifiers
 
 struct DiveExportView: View {
     let dive: Dive
-    let temps: [Temp_Sample]
+    let temps: [TemperatureSample]
     
     @State var isExporting = false
     

--- a/AWU2UDDF/Views/DiveExportView.swift
+++ b/AWU2UDDF/Views/DiveExportView.swift
@@ -26,7 +26,8 @@ struct DiveExportView: View {
             Text("Dive Time: \(settings.dateFormatter.string(from: dive.startTime))")
                 .font(.title3).padding()
             Text("Duration: \(Int((dive.duration() + 59.0) / 60.0)) min").padding()
-            Text("Max Depth: \(settings.displayDepth(metres: dive.MaxDepth(), shortUnits: false))").padding()
+            Text("Max Depth: \(settings.displayDepth(metres: dive.maxDepth(), shortUnits: false))").padding()
+            Text("Average Depth: \(settings.displayDepth(metres: dive.avgDepth(), shortUnits: false))").padding()
     
             Button {
                 isExporting = true

--- a/AWU2UDDF/Views/DiveExportView.swift
+++ b/AWU2UDDF/Views/DiveExportView.swift
@@ -54,7 +54,7 @@ struct DiveExportView: View {
                 .padding()
                 .opacity(exportDocument == nil ? 0.5 : 1)
                 .disabled(exportDocument == nil)
-                .fileExporter(isPresented: $isExporting, document: exportDocument, contentType: UTType.xml, defaultFilename: dive.defaultUDDFFilename()) {      result in
+                .fileExporter(isPresented: $isExporting, document: exportDocument, contentType: UTType.xml, defaultFilename: dive.defaultUDDFFilename()) { result in
                     switch result {
                     case .success(let url):
                         print("Saved to \(url)")
@@ -66,9 +66,9 @@ struct DiveExportView: View {
                     ProgressView()
                 }
             }
-                Spacer()
-                Spacer()
-            }
+            Spacer()
+            Spacer()
+        }
         .onAppear(perform: self.generateExportDocument)
     }
 }

--- a/AWU2UDDF/Views/DiveRowView.swift
+++ b/AWU2UDDF/Views/DiveRowView.swift
@@ -13,7 +13,7 @@ struct DiveRowView: View {
     @EnvironmentObject var settings: Settings
     
     var body: some View {
-        let duration = Int((dive.Duration() + 59.0) / 60.0)
+        let duration = Int((dive.duration() + 59.0) / 60.0)
         HStack {
             Text(settings.dateFormatter.string(from: dive.startTime))
                 .frame(width: 150, alignment: .leading)
@@ -21,7 +21,7 @@ struct DiveRowView: View {
             Text("\(duration) min")
                 .frame(width: 60, alignment: .trailing)
 
-            Text(settings.displayDepth(metres: dive.MaxDepth()))
+            Text(settings.displayDepth(metres: dive.maxDepth()))
                 .frame(width: 60, alignment: .trailing)
         }
     }


### PR DESCRIPTION
Mostly refactoring names of fields and simplifying some calculations.

Bigger change is making the UDDF file be generated asynchronously, removing the small pause/lag that would occur when tapping on a dive row to go to the export view.

(This will have conflicts with some of my other in-flight PRs, so I can rebase this if/when you merge those)