### PR TITLE
XML generation refactor

### DIFF
--- a/AWU2UDDF/Models/UDDFModel.swift
+++ b/AWU2UDDF/Models/UDDFModel.swift
@@ -82,7 +82,7 @@ struct XMLDocument {
 }
 
 // Class for building a UDDF XML string to store in file.
-// TODO: this could now just be a stand-alone function, it has no state...maybe a single static method
+// TODO: this could now just be a stand-alone function, it has no state...maybe a single static method, maybe a method on UDDFFile instead
 class UDDF {
     
     // Build the <generator> section of UDDF

--- a/AWU2UDDF/Models/UDDFModel.swift
+++ b/AWU2UDDF/Models/UDDFModel.swift
@@ -31,15 +31,9 @@ struct XMLNode {
     let attributes: [String:String]?
     let children: [Child]
     
-    init(title: String, attributes: [String : String]?, children: [XMLNode]) {
+    init(title: String, attributes: [String : String]? = nil, children: [XMLNode] = []) {
         self.title = title
         self.attributes = attributes
-        self.children = children.map({ .xml($0) })
-    }
-    
-    init(title: String, children: [XMLNode]) {
-        self.title = title
-        self.attributes = nil
         self.children = children.map({ .xml($0) })
     }
     
@@ -109,9 +103,7 @@ class UDDF {
                         XMLNode(title: "owner", attributes: ["id": "owner"],
                                 children: [
                                     XMLNode(title: "personal",
-                                            children: [
-                                                XMLNode(title: "firstname", children: []),
-                                                XMLNode(title: "lastname", children: [])]),
+                                            children: [XMLNode(title: "firstname"), XMLNode(title: "lastname")]),
                                     XMLNode(title: "equipment",
                                             children: [
                                                 XMLNode(title: "divecomputer",
@@ -119,7 +111,7 @@ class UDDF {
                                                         children: [
                                                             XMLNode(title: "name", textContent: "Apple Watch Ultra"),
                                                             XMLNode(title: "model", textContent: "Apple Watch Ultra")])])]),
-                        XMLNode(title: "buddy", children: [])])
+                        XMLNode(title: "buddy")])
     }
     
     // Build the <profile> section of UDDF by matching depth samples with temperature samples
@@ -157,8 +149,8 @@ class UDDF {
                                         children: [
                                             generatorElem(),
                                             diverElem(),
-                                            XMLNode(title: "divesite", children: []),
-                                            XMLNode(title: "gasdefinitions", children: []),
+                                            XMLNode(title: "divesite"),
+                                            XMLNode(title: "gasdefinitions"),
                                             profileDataElements(startTime: startTime, profile: profile, temps: tempsByDate),
                                         ]))
         


### PR DESCRIPTION
This is kinda unnecessary...mostly just for fun. I re-wrote the XML generation to use a more structured approach, instead of string concatenation.

The argument would be that it makes it harder to accidentally have invalid syntax in the XML (mis-matched tags, bad quotes), consistent indentation. Maybe will make it easier in the future to have other data added in (e.g. if we wanted to make a setting to let the user set the diver name in the export).